### PR TITLE
fixes: win32 cpu and ram; resurrect extension

### DIFF
--- a/plugin/tabline/components/window/cpu.lua
+++ b/plugin/tabline/components/window/cpu.lua
@@ -16,9 +16,9 @@ return {
     local success, result
     if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
       success, result = wezterm.run_child_process {
-        'powershell',
-        '-Command',
-        'Get-WmiObject -Query "SELECT * FROM Win32_Processor" | ForEach-Object -MemberName LoadPercentage',
+        'cmd.exe',
+        '/C',
+        'wmic cpu get loadpercentage',
       }
     elseif wezterm.target_triple == 'x86_64-unknown-linux-gnu' then
       success, result = wezterm.run_child_process {
@@ -34,11 +34,16 @@ return {
       }
     end
 
-    if not success then
+    if not success or not result then
       return ''
     end
 
-    local cpu = result:gsub('^%s*(.-)%s*$', '%1')
+    local cpu
+    if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
+      cpu = result:match("%d+")
+    else
+      cpu = result:gsub('^%s*(.-)%s*$', '%1')
+    end
 
     if wezterm.target_triple == '-86_64-apple-darwin' or wezterm.target_triple == 'aarch64-apple-darwin' then
       success, result = wezterm.run_child_process {

--- a/plugin/tabline/components/window/ram.lua
+++ b/plugin/tabline/components/window/ram.lua
@@ -47,7 +47,6 @@ return {
       ram = string.format('%.2f GB', total_memory)
     elseif wezterm.target_triple == 'x86_64-pc-windows-msvc' then
       ram = result:match("%d+")
-      wezterm.log_warn(ram)
       ram = string.format('%.2f GB', tonumber(ram) / 1024 / 1024)
     end
 

--- a/plugin/tabline/extensions/resurrect.lua
+++ b/plugin/tabline/extensions/resurrect.lua
@@ -9,7 +9,7 @@ return {
     },
     sections = {
       tabline_a = {
-        ' Resurrect Workspace ',
+        ' ' .. wezterm.nerdfonts.md_sleep_off .. ' Resurrect Workspace ',
       },
       tabline_c = {},
       tab_active = {},


### PR DESCRIPTION
This PR fixes the ram and cpu modules on Windows.

Also fixes the filename of `resurrect.lua` so the extension loads as expected.