### PR TITLE
feat: Zoom indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ And the `tab_active` and `tab_inactive` components which are grouped under Tab a
   - `parent` (parent directory)
   - `process` (process name)
   - `tab_index` (tab index)
+  - `zoomed` (indicator if tab has zoomed pane)
 
 #### Custom components
 

--- a/plugin/tabline/components/tab/zoomed.lua
+++ b/plugin/tabline/components/tab/zoomed.lua
@@ -1,0 +1,18 @@
+local wezterm = require('wezterm')
+
+return {
+  update = function(tab, opts)
+    for _, pane in ipairs(tab.panes) do
+      if pane.is_zoomed then
+        if opts.icons_enabled then
+          local icon = opts.icon and opts.icon or wezterm.nerdfonts.oct_zoom_in
+          return icon
+        else
+          return 'Z'
+        end
+      end
+
+      return ''
+    end
+  end,
+}

--- a/plugin/tabline/util.lua
+++ b/plugin/tabline/util.lua
@@ -133,7 +133,7 @@ function M.create_component(name, opts, object, attributes)
     left_padding_element = { Text = left_padding }
     right_padding_element = { Text = right_padding }
   end
-  if opts.icons_enabled and opts.icon then
+  if opts.icons_enabled and opts.icon and not name == 'zoomed' then
     local icon_name = {}
     table.insert(icon_name, left_padding_element)
     if type(opts.icon) == 'table' then


### PR DESCRIPTION
Adds a component that shows an indicator if a tab has a zoomed pane.

If `icons_enabled = false`, it will be show the letter `Z`, otherwise it will be `wezterm.nerdfonts.oct_zoom_in` or a custom icon specified in a user's config like:
```lua
      tab_active = { 
        -- ...
        {
          'zoomed',
          icons_enabled = true,
          icon = wezterm.nerdfonts.fa_bars, -- user-specified icon
        },
        -- ...
      },