### PR TITLE
Improved foreground process identification

### DIFF
--- a/plugin/tabline/components/tab/process.lua
+++ b/plugin/tabline/components/tab/process.lua
@@ -8,15 +8,17 @@ return {
       foreground_process_name = foreground_process_name:match('([^/\\]+)[/\\]?$') or foreground_process_name
     end
 
-    -- fallback to the domain name if it is a non-local domain
-    if foreground_process_name == '' then
-      foreground_process_name = tab.active_pane.domain_name ~= 'local' and tab.active_pane.domain_name or ''
-    end
-
     -- fallback to the title if the foreground process name is unavailable
+    -- Wezterm uses OSC 1/2 escape sequences to guess the process name and set the title
+    -- see https://wezfurlong.org/wezterm/config/lua/pane/get_title.html
     -- title defaults to 'wezterm' if another name is unavailable
     if foreground_process_name == '' then
       foreground_process_name = (tab.tab_title and #tab.tab_title > 0) and tab.tab_title or tab.active_pane.title
+    end
+
+    -- if the tab active pane contains a non-local domain, use the domain name
+    if foreground_process_name == 'wezterm' then
+      foreground_process_name = tab.active_pane.domain_name ~= 'local' and tab.active_pane.domain_name or 'wezterm'
     end
 
     return foreground_process_name

--- a/plugin/tabline/components/tab/process.lua
+++ b/plugin/tabline/components/tab/process.lua
@@ -2,10 +2,23 @@ local foreground_process_name = ''
 
 return {
   update = function(tab)
+    -- get the foreground process name if available
     if tab.active_pane and tab.active_pane.foreground_process_name then
       foreground_process_name = tab.active_pane.foreground_process_name
-      foreground_process_name = foreground_process_name:match('([^/]+)/?$') or foreground_process_name
+      foreground_process_name = foreground_process_name:match('([^/\\]+)[/\\]?$') or foreground_process_name
     end
-    return foreground_process_name ~= '' and foreground_process_name or 'ssh'
+
+    -- fallback to the domain name if it is a non-local domain
+    if foreground_process_name == '' then
+      foreground_process_name = tab.active_pane.domain_name ~= 'local' and tab.active_pane.domain_name or ''
+    end
+
+    -- fallback to the title if the foreground process name is unavailable
+    -- title defaults to 'wezterm' if another name is unavailable
+    if foreground_process_name == '' then
+      foreground_process_name = (tab.tab_title and #tab.tab_title > 0) and tab.tab_title or tab.active_pane.title
+    end
+
+    return foreground_process_name
   end,
 }


### PR DESCRIPTION
The PR updates the match statement so that it covers Windows directories (backslash for dirs) as well as unix-based systems (forward slash).

I created this as a draft because I'd like to test it some more on various platforms with different processes running and also to get some feedback.

If a foreground process isn't found (which is expected behaviour for most non-local domains), the idea is to then check the domain name. If it isn't a local domain, we would then use the domain name for the process name, because resolving the foreground process won't be possible.

If we're dealing with a local domain and couldn't resolve a foreground process name, the idea is to use the tab title as the process name. Wezterm will attempt to resolve the OSC 1/2 sequences to fill in a title name (see [get_title in Wezterm docs](https://wezfurlong.org/wezterm/config/lua/pane/get_title.html)), and the title will default to "Wezterm" otherwise.

I know Windows has some odd behaviour with OSC 2 sequences that I'd like to test further as well to see what the tab title gets set to, and whether we would need to do some matching for Windows PCs.