### PR TITLE
fix: event not hiding

### DIFF
--- a/plugin/tabline/component.lua
+++ b/plugin/tabline/component.lua
@@ -131,6 +131,9 @@ local function left_section()
 end
 
 function M.set_status(window)
+  if not window.window_id then
+    return
+  end
   create_attributes(window)
   create_sections(window)
   window:set_left_status(wezterm.format(left_section()))

--- a/plugin/tabline/extension.lua
+++ b/plugin/tabline/extension.lua
@@ -7,7 +7,7 @@ local M = {}
 local function set_attributes(sections, colors, window)
   config.sections = sections
   config.colors.normal_mode = colors
-  if window.window_id then
+  if window then
     require('tabline.component').set_status(window)
   end
 end


### PR DESCRIPTION
The resurrect extension 'periodic_save' event wasn't hiding after the 7 second delay. I don't know why there wouldn't be a `window_id`, but this fixed it for me.