### PR TITLE
feat(extension): support presentation.wez

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ extensions = { 'resurrect' }
 - resurrect
 - smart_workspace_switcher
 - quick_domains
+- presentation
 
 #### Custom extensions
 

--- a/plugin/tabline/extensions/presentation.lua
+++ b/plugin/tabline/extensions/presentation.lua
@@ -1,0 +1,29 @@
+local wezterm = require('wezterm')
+local config = require('tabline.config')
+
+return {
+  {
+    events = {
+      show = 'xarvex.presentation.activate',
+      hide = 'xarvex.presentation.deactivate',
+    },
+    sections = {
+      tabline_a = {
+        ' ' .. wezterm.nerdfonts.md_presentation_play .. ' Presenting ',
+      },
+      tabline_b = { 'workspace' },
+
+      -- Clear for a focused presentation.
+      tabline_c = { '' },
+      tabline_x = { '' },
+      tabline_y = { '' },
+      tabline_z = { 'datetime' },
+      tab_active = {},
+      tab_inactive = {},
+    },
+    colors = {
+      a = { bg = config.colors.scheme.ansi[7] },
+      b = { fg = config.colors.scheme.ansi[7] },
+    },
+  },
+}


### PR DESCRIPTION
See original request for the events: https://github.com/xarvex/presentation.wez/issues/1
Events were added to presentation.wez in https://github.com/xarvex/presentation.wez/commit/55f4bbfe17d3273a2347d6e04903fcecd3f2ee11.

Not 100% sure on the desired idea for the colors and active sections; I opted that most likely one would wish the "extra" information be cleared out when in present mode, but feel free to edit as seen fit.

Tested working, and formatted with stylua.