### PR TITLE
Discrepancy between right Nerdfont tab seperator bg color on inactive tabs fixed

### DIFF
--- a/plugin/tabline/component.lua
+++ b/plugin/tabline/component.lua
@@ -7,17 +7,17 @@ local mode = require('tabline.components.window.mode')
 local M = {}
 
 local left_section_separator =
-  { Text = config.opts.options.section_separators.left or config.opts.options.section_separators }
+{ Text = config.opts.options.section_separators.left or config.opts.options.section_separators }
 local right_section_separator =
-  { Text = config.opts.options.section_separators.right or config.opts.options.section_separators }
+{ Text = config.opts.options.section_separators.right or config.opts.options.section_separators }
 local left_component_separator =
-  { Text = config.opts.options.component_separators.left or config.opts.options.component_separators }
+{ Text = config.opts.options.component_separators.left or config.opts.options.component_separators }
 local right_component_separator =
-  { Text = config.opts.options.component_separators.right or config.opts.options.component_separators }
+{ Text = config.opts.options.component_separators.right or config.opts.options.component_separators }
 
 local attributes_a, attributes_b, attributes_c, attributes_x, attributes_y, attributes_z = {}, {}, {}, {}, {}, {}
 local section_seperator_attributes_a, section_seperator_attributes_b, section_seperator_attributes_c, section_seperator_attributes_x, section_seperator_attributes_y, section_seperator_attributes_z =
-  {}, {}, {}, {}, {}, {}
+    {}, {}, {}, {}, {}, {}
 local tabline_a, tabline_b, tabline_c, tabline_x, tabline_y, tabline_z = {}, {}, {}, {}, {}, {}
 
 local function create_attributes(window)
@@ -101,12 +101,12 @@ local function create_sections(window)
       sections = util.deep_extend(util.deep_copy(sections), ext.sections)
     end
   end
-  tabline_a = insert_component_separators(util.extract_components(sections.tabline_a, attributes_a, window), true)
-  tabline_b = insert_component_separators(util.extract_components(sections.tabline_b, attributes_b, window), true)
-  tabline_c = insert_component_separators(util.extract_components(sections.tabline_c, attributes_c, window), true)
-  tabline_x = insert_component_separators(util.extract_components(sections.tabline_x, attributes_x, window), false)
-  tabline_y = insert_component_separators(util.extract_components(sections.tabline_y, attributes_y, window), false)
-  tabline_z = insert_component_separators(util.extract_components(sections.tabline_z, attributes_z, window), false)
+  tabline_a = insert_component_separators(util.extract_components(sections.tabline_a, attributes_a, window, true), true)
+  tabline_b = insert_component_separators(util.extract_components(sections.tabline_b, attributes_b, window, true), true)
+  tabline_c = insert_component_separators(util.extract_components(sections.tabline_c, attributes_c, window, true), true)
+  tabline_x = insert_component_separators(util.extract_components(sections.tabline_x, attributes_x, window, true), false)
+  tabline_y = insert_component_separators(util.extract_components(sections.tabline_y, attributes_y, window, true), false)
+  tabline_z = insert_component_separators(util.extract_components(sections.tabline_z, attributes_z, window, true), false)
 end
 
 local function right_section()

--- a/plugin/tabline/util.lua
+++ b/plugin/tabline/util.lua
@@ -68,7 +68,7 @@ local function require_component(object, v)
   return component
 end
 
-function M.extract_components(components_opts, attributes, object)
+function M.extract_components(components_opts, attributes, object, format)
   local component_opts = require('tabline.config').component_opts
   local components = {}
   for _, v in ipairs(components_opts) do
@@ -83,9 +83,9 @@ function M.extract_components(components_opts, attributes, object)
           if result.default_opts then
             opts = M.deep_extend(opts, result.default_opts)
           end
-          local component = M.create_component(result.update(object, opts), opts, object, attributes)
+          local component = M.create_component(result.update(object, opts), opts, object, attributes, format)
           if component then
-            table.insert(components, component)
+            M.insert_elements(components, component)
           end
         else
           table.insert(components, { Text = v .. '' })
@@ -100,9 +100,9 @@ function M.extract_components(components_opts, attributes, object)
         end
         opts = M.deep_extend(opts, v)
         table.remove(opts, 1)
-        local component = M.create_component(result.update(object, opts), opts, object, attributes)
+        local component = M.create_component(result.update(object, opts), opts, object, attributes, format)
         if component then
-          table.insert(components, component)
+          M.insert_elements(components, component)
         end
       end
     elseif type(v) == 'function' then
@@ -114,7 +114,7 @@ function M.extract_components(components_opts, attributes, object)
   return components
 end
 
-function M.create_component(name, opts, object, attributes)
+function M.create_component(name, opts, object, attributes, format)
   if name == nil then
     return
   end
@@ -128,6 +128,7 @@ function M.create_component(name, opts, object, attributes)
     name = ''
   end
 
+  local result
   local left_padding_element, right_padding_element
   local left_padding, right_padding
   if opts.padding then
@@ -177,11 +178,14 @@ function M.create_component(name, opts, object, attributes)
       table.insert(icon_name, { Text = name })
     end
     table.insert(icon_name, right_padding_element)
-    name = wezterm.format(icon_name)
+    result = icon_name
+    if format then
+      result = { { Text = wezterm.format(icon_name) } }
+    end
   else
-    name = left_padding .. name .. right_padding
+    result = { { Text = left_padding .. name .. right_padding } }
   end
-  return { Text = name }
+  return result
 end
 
 function M.overwrite_icon(opts, new_icon)


### PR DESCRIPTION
# Fix background color reset issue in tab rendering

## Problem
When rendering tabs with custom formatting, the background color is unexpectedly reset to default due to how `wezterm.format` handles control sequences optimization. This issue was reported in #40.

## Root Cause
The `wezterm.format` function tries to optimize shell control sequences. When given a sequence like:
```
FG_1 BG_1 TEXT FG_2 BG_1
```

It removes what it considers redundant commands (like the second `BG_1`). However, it doesn't account for control sequences within TEXT that might reset background and foreground colors (`\u{1b}[39m\u{1b}[49m`).

`tabline` tries to render tab like this:
```
    {
        "Foreground": {
            "Color": "#181825",  // FG_1
        },
    },
    {
        "Background": {
            "Color": "#181825",  // BG_1
        },
    },
    {
        "Text": "\u{e0b6}",       // SEP_RIGHT
    },
    {
        "Foreground": {
            "Color": "#cdd6f4",  // FG_2
        },
    },
    {
        "Background": {
            "Color": "#181825",  // BG_1
        },
    },
    {
        "Text": " 1 ",
    },
    {
        "Text": "\u{1b}[38:2::245:224:220m\u{f023a} \u{1b}[38:2::205:214:244m\u{1b}[48:2::24:24:37mfish \u{1b}[39m\u{1b}[49m",  // process name with icon, rendered in create_component function
    },
    table: 0x600003359700,  // FG_2
    table: 0x60000335ac40,  // BG_1
    {
        "Text": "\u{e0b4}",       // SEP_LEFT 
    },
```

And this is finally rendered to

```
\u{1b}[38:2::24:24:37m\u{1b}[48:2::24:24:37m\u{e0b6}\u{1b}[38:2::205:214:244m 1 \u{1b}[38:2::245:224:220m\u{f023a} \u{1b}[38:2::205:214:244m\u{1b}[48:2::24:24:37mfish \u{1b}[39m\u{1b}[49m\u{1b}[38:2::24:24:37m\u{e0b4}\u{1b}[39m\u{1b}[49m
```
What can be interpreted as  

```
FG_1 
BG_1                       <======= BG_1 was initially set
SEP_RIGHT 
FG_2 
1 
  > FG_3                  <======= This part is from formatted Text
  > \u{f023a} 
  > FG_2 
  > BG_1 
  > fish 
  > RESET_FG 
  > RESET_BG        <======= Here we lost BG
FG_1                       <======= Because of optimization mentioned in the beginning BG_1 is not restored
SEP_LEFT 
RESET_FG 
RESET_BG
```

## Solution

Added an optional parameter to create_component function that allows disabling internal formatting. This prevents the unwanted color resets while maintaining the component's visual integrity.


