### PR TITLE
Fix for RAM shown incorrectly on linux machines, changes in awk bash script. Closes #71

### DIFF
--- a/plugin/tabline/components/window/ram.lua
+++ b/plugin/tabline/components/window/ram.lua
@@ -21,7 +21,7 @@ return {
         'wmic OS get FreePhysicalMemory',
       }
     elseif string.match(wezterm.target_triple, 'linux') ~= nil then
-      success, result = wezterm.run_child_process { 'bash', '-c', 'free -m | awk \'NR==2{printf "%.2f", $3*100/$2 }\'' }
+      success, result = wezterm.run_child_process { 'bash', '-c', 'free -m | awk \'NR==3{printf "%.2f", $3/1000 }\'' }
     elseif string.match(wezterm.target_triple, 'darwin') ~= nil then
       success, result = wezterm.run_child_process { 'vm_stat' }
     end


### PR DESCRIPTION
Regarding issue #71 
Previous script calculated the percentage of RAM used using awk, fixed the script so it just outputs the amount of RAM in GB.