### PR TITLE
changes to select the corrent RAM row from free -m command

### DIFF
--- a/plugin/tabline/components/window/ram.lua
+++ b/plugin/tabline/components/window/ram.lua
@@ -21,7 +21,7 @@ return {
         'wmic OS get FreePhysicalMemory',
       }
     elseif string.match(wezterm.target_triple, 'linux') ~= nil then
-      success, result = wezterm.run_child_process { 'bash', '-c', 'free -m | awk \'NR==3{printf "%.2f", $3/1000 }\'' }
+      success, result = wezterm.run_child_process { 'bash', '-c', 'free -m | awk \'NR==2{printf "%.2f", $3/1000 }\'' }
     elseif string.match(wezterm.target_triple, 'darwin') ~= nil then
       success, result = wezterm.run_child_process { 'vm_stat' }
     end


### PR DESCRIPTION
Closes #73 
awk script's row had been mistakenly changed from 2 to 3. Returned to correct row, it should correctly display the used ram now.