### PR TITLE
fix: used ram calculation formula for darwin

### DIFF
--- a/plugin/tabline/components/window/ram.lua
+++ b/plugin/tabline/components/window/ram.lua
@@ -35,16 +35,17 @@ return {
       ram = string.format('%.2f GB', tonumber(result))
     elseif string.match(wezterm.target_triple, 'darwin') ~= nil then
       local page_size = result:match('page size of (%d+) bytes')
-      local pages_free = result:match('Pages free: +(%d+).')
-      local pages_active = result:match('Pages active: +(%d+).')
-      local pages_inactive = result:match('Pages inactive: +(%d+).')
-      local pages_speculative = result:match('Pages speculative: +(%d+).')
-      local total_memory = (pages_free + pages_active + pages_inactive + pages_speculative)
+      local anonymous_pages = result:match('Anonymous pages: +(%d+).')
+      local pages_purgeable = result:match('Pages purgeable: +(%d+).')
+      local app_memory = anonymous_pages - pages_purgeable
+      local wired_memory = result:match('Pages wired down: +(%d+).')
+      local compressed_memory = result:match('Pages occupied by compressor: +(%d+).')
+      local used_memory = (app_memory + wired_memory + compressed_memory)
         * page_size
         / 1024
         / 1024
         / 1024
-      ram = string.format('%.2f GB', total_memory)
+      ram = string.format('%.2f GB', used_memory)
     elseif string.match(wezterm.target_triple, 'windows') ~= nil then
       ram = result:match('%d+')
       ram = string.format('%.2f GB', tonumber(ram) / 1024 / 1024)


### PR DESCRIPTION
Calculating used memory is a complex problem. 
The code estimates used memory on macOS, and the verification results closely match those from iStat Menus.
<img width="606" alt="Screenshot 2025-04-03 at 02 42 41" src="https://github.com/user-attachments/assets/4da9481b-b56f-4b6a-8eb6-db7b6227674a" />
**Notes：**
**​App Memory:** Active application memory minus purgeable pages (memory macOS can reclaim if needed)
**​Wired Memory:** Critical system memory that cannot be compressed/swapped
**​Compressed Memory:** RAM optimized via real-time compression (macOS memory management feature)
**Used Memory**: App Memory+​Wired Memory+Compressed Memory

**Refer to this link：**
[is-there-a-command-line-tool-that-accurately-describes-the-amount-of-used-memory](https://apple.stackexchange.com/questions/423717/is-there-a-command-line-tool-that-accurately-describes-the-amount-of-used-memory)
