### PR TITLE
fix: force awk to use dot notation

### DIFF
--- a/plugin/tabline/components/window/cpu.lua
+++ b/plugin/tabline/components/window/cpu.lua
@@ -33,13 +33,13 @@ return {
       success, result = wezterm.run_child_process {
         'bash',
         '-c',
-        "awk '/^cpu / {print ($2+$4)*100/($2+$4+$5)}' /proc/stat",
+        "LC_NUMERIC=C awk '/^cpu / {print ($2+$4)*100/($2+$4+$5)}' /proc/stat",
       }
     elseif string.match(wezterm.target_triple, 'darwin') ~= nil then
       success, result = wezterm.run_child_process {
         'bash',
         '-c',
-        'ps -A -o %cpu | awk \'{s+=$1} END {print s ""}\'',
+        'ps -A -o %cpu | LC_NUMERIC=C awk \'{s+=$1} END {print s ""}\'',
       }
     end
 

--- a/plugin/tabline/components/window/ram.lua
+++ b/plugin/tabline/components/window/ram.lua
@@ -30,7 +30,8 @@ return {
         }
       end
     elseif string.match(wezterm.target_triple, 'linux') ~= nil then
-      success, result = wezterm.run_child_process { 'bash', '-c', 'free -m | awk \'NR==2{printf "%.2f", $3/1000 }\'' }
+      success, result =
+        wezterm.run_child_process { 'bash', '-c', 'free -m | LC_NUMERIC=C awk \'NR==2{printf "%.2f", $3/1000 }\'' }
     elseif string.match(wezterm.target_triple, 'darwin') ~= nil then
       success, result = wezterm.run_child_process { 'vm_stat' }
     end
@@ -49,11 +50,7 @@ return {
       local app_memory = anonymous_pages - pages_purgeable
       local wired_memory = result:match('Pages wired down: +(%d+).')
       local compressed_memory = result:match('Pages occupied by compressor: +(%d+).')
-      local used_memory = (app_memory + wired_memory + compressed_memory)
-        * page_size
-        / 1024
-        / 1024
-        / 1024
+      local used_memory = (app_memory + wired_memory + compressed_memory) * page_size / 1024 / 1024 / 1024
       ram = string.format('%.2f GB', used_memory)
     elseif string.match(wezterm.target_triple, 'windows') ~= nil then
       if opts.use_pwsh then


### PR DESCRIPTION
With my locale (nl_NL.UTF-8), awk prints "123,45" instead of "123.45", which leads to tonumber(result) failing, which leads to format() getting nil at line 44 in ram.lua, and failing with error.
This fixes it there and in cpu, for linux and Mac. Not sure of Mac LC_* semantics though