### PR TITLE
feat(modal.wezterm): add compatibility with modal.wezterm

### DIFF
--- a/plugin/tabline/config.lua
+++ b/plugin/tabline/config.lua
@@ -73,6 +73,21 @@ local function get_colors(theme)
       b = { fg = colors.ansi[3], bg = surface },
       c = { fg = colors.foreground, bg = background },
     },
+    ui_mode = {
+      a = { fg = background, bg = colors.ansi[2] },
+      b = { fg = colors.ansi[2], bg = surface },
+      c = { fg = colors.foreground, bg = background },
+    },
+    scroll_mode = {
+      a = { fg = background, bg = colors.ansi[6] },
+      b = { fg = colors.ansi[6], bg = surface },
+      c = { fg = colors.foreground, bg = background },
+    },
+    visual_mode = {
+      a = { fg = background, bg = colors.ansi[7] },
+      b = { fg = colors.ansi[7], bg = surface },
+      c = { fg = colors.foreground, bg = background },
+    },
     tab = {
       active = { fg = colors.ansi[5], bg = surface },
       inactive = { fg = colors.foreground, bg = background },


### PR DESCRIPTION
This MR adds three modes (ui_mode, scroll_mode, and visual_mode) to improve compatibility with MLFlexer’s modal.wezterm.
<img width="146" height="26" alt="image" src="https://github.com/user-attachments/assets/0ebe3492-b022-437d-9e26-ef12187c5343" />
<img width="171" height="25" alt="image" src="https://github.com/user-attachments/assets/90aaf57b-19a8-4ab5-990e-b3b72bde09db" />
I’ve also submitted a [request ](https://github.com/MLFlexer/modal.wezterm/pull/35)to modal.wezterm for backward compatibility with tabline.wez.
