### PR TITLE
feat: pass pane information to custom component functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ And the `tab_active` and `tab_inactive` components which are grouped under Tab a
 
 #### Custom components
 
-##### Lua functions as tabline component
+##### Lua functions as component
 
 ```lua
 local function hello()
@@ -324,15 +324,15 @@ sections = { tabline_a = { hello } }
 ```
 
 > [!NOTE]
-> Functions receive the `Window` object or `TabInformation` object as the first argument depending on the component group
+> Custom tabline component functions are passed the [Window](https://wezfurlong.org/wezterm/config/lua/window/index.html) and [Pane](https://wezfurlong.org/wezterm/config/lua/pane/index.html) objects as first and second argument. Custom tab component functions receive the [TabInformation](https://wezfurlong.org/wezterm/config/lua/TabInformation.html) and [PaneInformation](https://wezfurlong.org/wezterm/config/lua/PaneInformation.html) objects, respectively.
 
-##### Text string as tabline component
+##### Text string as component
 
 ```lua
 sections = { tabline_a = { 'Hello World' } }
 ```
 
-##### WezTerm Formatitem as tabline component
+##### WezTerm Formatitem as component
 
 You can find all the available format items [here](https://wezfurlong.org/wezterm/config/lua/wezterm/format.html). The `ResetAttributes` format item has been overwritten to reset all attributes back to the default for that component instead of the WezTerm default.
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -93,12 +93,12 @@ package.path = package.path
 function M.setup(opts)
   require('tabline.config').set(opts)
 
-  wezterm.on('update-status', function(window)
-    require('tabline.component').set_status(window)
+  wezterm.on('update-status', function(window, pane)
+    require('tabline.component').set_status(window, pane)
   end)
 
   wezterm.on('format-tab-title', function(tab, _, _, _, hover, _)
-    return require('tabline.tabs').set_title(tab, hover)
+    return require('tabline.tabs').set_title(tab, tab.active_pane, hover)
   end)
 
   require('tabline.extension').load()

--- a/plugin/tabline/component.lua
+++ b/plugin/tabline/component.lua
@@ -94,22 +94,25 @@ local function insert_component_separators(components, is_left)
   return components
 end
 
-local function create_sections(window)
+local function create_sections(window, pane)
   local sections = config.sections
   for _, ext in pairs(extension.extensions) do
     if ext.sections then
       sections = util.deep_extend(util.deep_copy(sections), ext.sections)
     end
   end
-  tabline_a = insert_component_separators(util.extract_components(sections.tabline_a, attributes_a, window, true), true)
-  tabline_b = insert_component_separators(util.extract_components(sections.tabline_b, attributes_b, window, true), true)
-  tabline_c = insert_component_separators(util.extract_components(sections.tabline_c, attributes_c, window, true), true)
+  tabline_a =
+    insert_component_separators(util.extract_components(sections.tabline_a, attributes_a, window, pane, true), true)
+  tabline_b =
+    insert_component_separators(util.extract_components(sections.tabline_b, attributes_b, window, pane, true), true)
+  tabline_c =
+    insert_component_separators(util.extract_components(sections.tabline_c, attributes_c, window, pane, true), true)
   tabline_x =
-    insert_component_separators(util.extract_components(sections.tabline_x, attributes_x, window, true), false)
+    insert_component_separators(util.extract_components(sections.tabline_x, attributes_x, window, pane, true), false)
   tabline_y =
-    insert_component_separators(util.extract_components(sections.tabline_y, attributes_y, window, true), false)
+    insert_component_separators(util.extract_components(sections.tabline_y, attributes_y, window, pane, true), false)
   tabline_z =
-    insert_component_separators(util.extract_components(sections.tabline_z, attributes_z, window, true), false)
+    insert_component_separators(util.extract_components(sections.tabline_z, attributes_z, window, pane, true), false)
 end
 
 local function right_section()
@@ -168,9 +171,9 @@ local function left_section()
   return result
 end
 
-function M.set_status(window)
+function M.set_status(window, pane)
   create_attributes(window)
-  create_sections(window)
+  create_sections(window, pane)
   window:set_left_status(wezterm.format(left_section()))
   window:set_right_status(wezterm.format(right_section()))
 end

--- a/plugin/tabline/tabs.lua
+++ b/plugin/tabline/tabs.lua
@@ -35,15 +35,15 @@ local function create_attributes(hover)
   }
 end
 
-local function create_tab_content(tab)
+local function create_tab_content(tab, pane)
   local sections = config.sections
   for _, ext in pairs(extension.extensions) do
     if ext.sections then
       sections = util.deep_extend(util.deep_copy(sections), ext.sections)
     end
   end
-  tab_active = util.extract_components(sections.tab_active, active_attributes, tab)
-  tab_inactive = util.extract_components(sections.tab_inactive, inactive_attributes, tab)
+  tab_active = util.extract_components(sections.tab_active, active_attributes, tab, pane)
+  tab_inactive = util.extract_components(sections.tab_inactive, inactive_attributes, tab, pane)
 end
 
 local function tabs(tab)
@@ -67,12 +67,12 @@ local function tabs(tab)
   return result
 end
 
-M.set_title = function(tab, hover)
+M.set_title = function(tab, pane, hover)
   if not config.opts.options.tabs_enabled then
     return
   end
   create_attributes(hover)
-  create_tab_content(tab)
+  create_tab_content(tab, pane)
   return tabs(tab)
 end
 

--- a/plugin/tabline/util.lua
+++ b/plugin/tabline/util.lua
@@ -68,7 +68,7 @@ local function require_component(object, v)
   return component
 end
 
-function M.extract_components(components_opts, attributes, object, format)
+function M.extract_components(components_opts, attributes, object, pane, format)
   local component_opts = require('tabline.config').component_opts
   local components = {}
   for _, v in ipairs(components_opts) do
@@ -106,7 +106,7 @@ function M.extract_components(components_opts, attributes, object, format)
         end
       end
     elseif type(v) == 'function' then
-      table.insert(components, { Text = v(object) .. '' })
+      table.insert(components, { Text = v(object, pane) .. '' })
     elseif type(v) == 'table' then
       table.insert(components, v)
     end


### PR DESCRIPTION
This commit allows users to write custom components that show pane-related information. For example, it enables displaying the current pane's process or working directory as a tabline component.