### PR TITLE
fix: get windows used ram memory

### DIFF
--- a/plugin/tabline/components/window/ram.lua
+++ b/plugin/tabline/components/window/ram.lua
@@ -20,14 +20,21 @@ return {
         success, result = wezterm.run_child_process {
           'powershell.exe',
           '-Command',
-          'Get-CimInstance Win32_OperatingSystem | Select-Object -ExpandProperty FreePhysicalMemory',
+          'Get-CimInstance Win32_OperatingSystem | ForEach-Object { $_.TotalVisibleMemorySize - $_.FreePhysicalMemory }',
         }
       else
-        success, result = wezterm.run_child_process {
+        local free, total
+        success, free = wezterm.run_child_process {
           'cmd.exe',
           '/C',
-          'wmic OS get FreePhysicalMemory',
+          'wmic OS get FreePhysicalMemory'
         }
+        success, total = wezterm.run_child_process {
+          'cmd.exe',
+          '/C',
+          'wmic OS get TotalVisibleMemorySize'
+        }
+        result = tostring(tonumber(total:match('%d+')) - tonumber(free:match('%d+')))
       end
     elseif string.match(wezterm.target_triple, 'linux') ~= nil then
       success, result =


### PR DESCRIPTION
Hi Michael,

Sorry for the long delay but I finally got around it and reviewed the code to publish a PR and fix the issue #95. I tested it out on my Windows 11 laptop and it works just fine now.

Feel free to review this and let me know if that works for you.

Thanks!